### PR TITLE
fix ibkr parser asserting on unsettled cash

### DIFF
--- a/src/parser/ibkr_csv.py
+++ b/src/parser/ibkr_csv.py
@@ -85,7 +85,7 @@ def parse_ending_asserts(input_path, cash_account, portfolio_account, rows):
         row for row in rows if
             row['Name'] == 'Cash Report' and
             row['Type'] == 'Data' and
-            row['Currency Summary'] == 'Ending Cash'
+            row['Currency Summary'] == 'Ending Settled Cash'
     ]
     for row in ending_cash_rows:
         currency = row['Currency']


### PR DESCRIPTION
Changes
- Fixes IBKR parser - it used to assert on the unsettled cash balance, which conflicted with the actual booking dates.

Breaking
- None