### PR TITLE
do not remove historical price data when fetching new prices

### DIFF
--- a/src/fetch_prices.py
+++ b/src/fetch_prices.py
@@ -1,6 +1,6 @@
 import requests
 
-from utils import format_exact, format_number_exact, parse_num_us
+from utils import format_number_exact, parse_num_us
 
 QUERY_URL = "https://www.alphavantage.co/query"
 


### PR DESCRIPTION
Changes
- Historical price data is retained when fetching a new set of prices.
- The two sets are merged. Conflicts are resolved in favor of the newer data.

Breaking
- None, but the order of entries in the prices journal is now sorted by date/symbol_1/symbol_2 in that order (ascending).


Fixes #6 