### PR TITLE
Fetch compact price list from alphavantage

### DIFF
--- a/fetch_prices.py
+++ b/fetch_prices.py
@@ -16,7 +16,10 @@ def fetch(api_key, load, format_args):
 			result = requests.get(QUERY_URL, params={
 				"function": 'TIME_SERIES_DAILY',
 				"symbol": symbol,
-				"outputsize": "full",
+				# Full is only available on the premium plan
+				# Compact gives us 100 datapoints (~3 months)
+				# Given that we keep old datapoints and merge them with the new ones, this should be good enough in practice (as long as we never need historical price data)
+				"outputsize": "compact",
 				"apikey": api_key
 			})
 			result = result.json()


### PR DESCRIPTION
Full is no longer supported on the free plan, but given that we are
already keeping historical data and merging the new datapoints into it
this should work out okay.

https://www.alphavantage.co/documentation/#daily
> By default, outputsize=compact. Strings compact and full are accepted with the following specifications: compact returns only the latest 100 data points; full returns the full-length time series of 20+ years of historical data. The "compact" option is recommended if you would like to reduce the data size of each API call. The "compact" outputsize is available to both free and premium API keys. The "full" outputsize is available to premium keys. Please subscribe to any premium membership plan to unlock the outputsize=full capability.
