### PR TITLE
Add delay when fetching prices

### DIFF
--- a/fetch_prices.py
+++ b/fetch_prices.py
@@ -1,4 +1,5 @@
 import requests
+import time
 
 from .utils import format_number_exact, parse_num_us, escape_commodity
 
@@ -42,4 +43,8 @@ def fetch(api_key, load, format_args):
 				output += f"P {date} {escape_commodity(from_symbol)} {format_number_exact(price, format_args, min_decimal=4)} {escape_commodity(to_symbol)}\n"
 		else:
 			assert False, "Unknown type"
+
+		# Sleep for 1s between loads, per the rate limits imposed on Alphavantage's free plan
+		time.sleep(1)
+
 	return output


### PR DESCRIPTION
Respects alphavantage rate limits as per this response

{'Information': 'Thank you for using Alpha Vantage! Please consider spreading out your free API requests more sparingly (1 request per second). You may subscribe to any of the premium plans at https://www.alphavantage.co/premium/ to lift the free key rate limit (25 requests per day), raise the per-second burst limit, and instantly unlock all premium endpoints'}
